### PR TITLE
Fix bufnr() error in Windows.

### DIFF
--- a/autoload/capture.vim
+++ b/autoload/capture.vim
@@ -138,7 +138,7 @@ endfunction
 
 function! s:generate_unique_bufname(string)
     let nr = get(b:, 'capture_bufnamenr', 0)
-    let bufname = '[Capture #'.nr.': "'.a:string.'"]'
+    let bufname = '[Capture #'.nr.' "'.a:string.'"]'
     while bufexists(bufname)
         let nr += 1
         let bufname = '[Capture #'.nr.': "'.a:string.'"]'


### PR DESCRIPTION
Windows の場合、`bufnr()` の`{expr}`に `:` が含まれているとエラーになってしまうようなので修正しました。

``` vim
" 再現コード
:execute bufnr('[Capture #0: "mes"]', 1) "buffer"
" => E303: "[Capture #0: "mes"]" のスワップファイルを開けないのでリカバリは不可能です
```
