### PR TITLE
Fix s:set_bufname()

### DIFF
--- a/autoload/capture.vim
+++ b/autoload/capture.vim
@@ -155,6 +155,7 @@ function! s:set_bufname(bufname)
     let bufnr = bufnr(a:bufname)
     if bufnr == -1
         enew
+        " NOTE: Can not use the (") for ':file'
         file `=substitute(a:bufname, '"', "'", 'g')`
     else
         execute bufnr 'buffer'


### PR DESCRIPTION
#1 をちょっと対応してみました。

158行目で `"` から `'` へ置換しているのは `"` を含めた文字列を `file` に設定するとエラーになったため…。
