### PR TITLE
Add digraphs example to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,9 @@ Show Ex command output in a buffer
 ```viml
 :Capture !ls
 ```
+
+* Show currently defined digraphs in a buffer.
+
+```viml
+:Capture digraphs
+```


### PR DESCRIPTION
Adds an example showing how to see currently defined digraphs.

I'm not sure if you want to add a ton of example to the readme, so please feel free to close this if not.

I find this shortcut very useful, since who can remember all the digraph key combinations >__<

Thank you for the very useful plugin!