### PR TITLE
Exclude > that cannot be used as a buffer name in Windows

### DIFF
--- a/autoload/capture.vim
+++ b/autoload/capture.vim
@@ -166,7 +166,7 @@ function! s:name_first_bufname(q_args) abort
   " Get rid of invalid characters of buffer name on MS Windows.
   let q_args = a:q_args
   if s:is_mswin
-    let q_args = substitute(q_args, '[?*\\>]', '_', 'g')
+    let q_args = substitute(q_args, '[?*\\<>]', '_', 'g')
   endif
   " Generate a unique buffer name.
   let bufname = s:generate_unique_bufname(q_args)

--- a/autoload/capture.vim
+++ b/autoload/capture.vim
@@ -166,7 +166,7 @@ function! s:name_first_bufname(q_args) abort
   " Get rid of invalid characters of buffer name on MS Windows.
   let q_args = a:q_args
   if s:is_mswin
-    let q_args = substitute(q_args, '[?*\\]', '_', 'g')
+    let q_args = substitute(q_args, '[?*\\>]', '_', 'g')
   endif
   " Generate a unique buffer name.
   let bufname = s:generate_unique_bufname(q_args)


### PR DESCRIPTION
It seems that E480 occurs if the buffer name in Windows contains >.

`:Capture echo "abc"->substitute('c', 'd','g')`
capture: could not create capture buffer: Vim(file):E480: 該当はありません: `=substitute(bufname.bufname, '"', "'", 'g')`